### PR TITLE
Add amd64 Eloquent and Foxy; add gscam builder

### DIFF
--- a/docker/build_amd64_ros2_eloquent_base.sh
+++ b/docker/build_amd64_ros2_eloquent_base.sh
@@ -1,0 +1,9 @@
+# requires sudo privileges
+docker build --tag ros2_eloquent_base - <<EOF
+# Use UBUNTU 18.04 for OS
+FROM ubuntu:18.04
+#
+# Upgrade the OS
+RUN apt-get update && \
+    apt-get upgrade -y
+EOF

--- a/docker/build_amd64_ros2_foxy_base.sh
+++ b/docker/build_amd64_ros2_foxy_base.sh
@@ -1,0 +1,9 @@
+# requires sudo privileges
+docker build --tag ros2_foxy_base - <<EOF
+# Use UBUNTU 20.04 for OS
+FROM ubuntu:20.04
+#
+# Upgrade the OS
+RUN apt-get update && \
+    apt-get upgrade -y
+EOF

--- a/docker/build_clyde_eloquent_gscam.sh
+++ b/docker/build_clyde_eloquent_gscam.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -x
+
+# Run with rocker:
+# rocker --x11 --nvidia --user clyde_eloquent_desktop_gscam
+docker build --tag clyde_eloquent_desktop_gscam -f- ../scripts <<EOF
+
+# Start with osrf desktop image
+FROM osrf/ros:eloquent-desktop
+
+# Upgrade the OS
+RUN apt-get update && apt-get upgrade -y
+
+# Install locate and run updatedb, handy for development
+RUN apt-get install locate
+RUN updatedb
+
+# Add gstreamer
+COPY do_get_gstreamer.sh ./scripts/do_get_gstreamer.sh
+RUN ./scripts/do_get_gstreamer.sh
+
+# Deps for gscam:ros2
+RUN apt-get install -y ros-eloquent-camera-calibration-parsers
+RUN apt-get install -y ros-eloquent-camera-info-manager
+
+# Get gscam
+RUN mkdir /workspace/gscam/src -p
+WORKDIR /workspace/gscam/src
+RUN git clone https://github.com/clydemcqueen/gscam.git -b ros2
+
+# Build workspace
+WORKDIR /workspace/gscam
+RUN . /opt/ros/eloquent/setup.sh && colcon build
+
+# Set up entrypoint
+# TODO doesn't work??? Get permission denied when I run with rocker, with --user or without
+# COPY gscam_entrypoint.sh /entrypoint.sh
+# ENTRYPOINT ["/entrypoint.sh"]
+
+# Command
+# CMD ros2 run gscam gscam
+EOF

--- a/docker/build_dashing_gscam.sh
+++ b/docker/build_dashing_gscam.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -x
+# 
+docker build --tag ros2_prep_dashing -f- ../scripts <<EOF
+FROM ros2_dashing_base
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_prep_dashing.sh scripts/do_prep_dashing.sh
+RUN ./scripts/do_prep_dashing.sh
+EOF
+#
+docker build --tag ros2_get_dashing -f- ../scripts <<EOF
+FROM ros2_prep_dashing
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_dashing.sh ./scripts/do_get_dashing.sh
+RUN ./scripts/do_get_dashing.sh
+EOF
+#
+docker build --tag dashing_get_gstreamer -f- ../scripts <<EOF
+FROM ros2_get_dashing
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_gstreamer.sh ./scripts/do_get_gstreamer.sh
+RUN ./scripts/do_get_gstreamer.sh
+EOF
+#
+docker build --tag dashing_clone_gscam -f- ../scripts <<EOF
+FROM dashing_get_gstreamer
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_clone_gscam.sh ./scripts/do_clone_gscam.sh
+RUN ./scripts/do_clone_gscam.sh
+EOF
+#
+docker build --tag dashing_build_gscam -f- ../scripts <<EOF
+FROM dashing_clone_gscam
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_build_gscam_dashing.sh ./scripts/do_build_gscam_dashing.sh
+RUN ./scripts/do_build_gscam_dashing.sh
+EOF

--- a/docker/build_eloquent_gscam.sh
+++ b/docker/build_eloquent_gscam.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -x
+#
+docker build --tag ros2_prep_eloquent -f- ../scripts <<EOF
+FROM ros2_eloquent_base
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_prep_eloquent.sh scripts/do_prep_eloquent.sh
+RUN ./scripts/do_prep_eloquent.sh
+EOF
+#
+docker build --tag ros2_get_eloquent -f- ../scripts <<EOF
+FROM ros2_prep_eloquent
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_eloquent.sh ./scripts/do_get_eloquent.sh
+RUN ./scripts/do_get_eloquent.sh
+EOF
+#
+docker build --tag eloquent_get_gstreamer -f- ../scripts <<EOF
+FROM ros2_get_eloquent
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_gstreamer.sh ./scripts/do_get_gstreamer.sh
+RUN ./scripts/do_get_gstreamer.sh
+EOF
+#
+docker build --tag eloquent_clone_gscam -f- ../scripts <<EOF
+FROM eloquent_get_gstreamer
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_clone_gscam.sh ./scripts/do_clone_gscam.sh
+RUN ./scripts/do_clone_gscam.sh
+EOF
+#
+docker build --tag eloquent_build_gscam -f- ../scripts <<EOF
+FROM eloquent_clone_gscam
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_build_gscam_eloquent.sh ./scripts/do_build_gscam_eloquent.sh
+RUN ./scripts/do_build_gscam_eloquent.sh
+EOF

--- a/docker/build_foxy_gscam.sh
+++ b/docker/build_foxy_gscam.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -x
+#
+docker build --tag ros2_prep_foxy -f- ../scripts <<EOF
+FROM ros2_foxy_base
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_prep_foxy.sh scripts/do_prep_foxy.sh
+RUN ./scripts/do_prep_foxy.sh
+EOF
+#
+docker build --tag ros2_get_foxy -f- ../scripts <<EOF
+FROM ros2_prep_foxy
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_foxy.sh ./scripts/do_get_foxy.sh
+RUN ./scripts/do_get_foxy.sh
+EOF
+#
+docker build --tag foxy_get_gstreamer -f- ../scripts <<EOF
+FROM ros2_get_foxy
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_get_gstreamer.sh ./scripts/do_get_gstreamer.sh
+RUN ./scripts/do_get_gstreamer.sh
+EOF
+#
+docker build --tag foxy_clone_gscam -f- ../scripts <<EOF
+FROM foxy_get_gstreamer
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_clone_gscam.sh ./scripts/do_clone_gscam.sh
+RUN ./scripts/do_clone_gscam.sh
+EOF
+#
+docker build --tag foxy_build_gscam -f- ../scripts <<EOF
+FROM foxy_clone_gscam
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/Work
+COPY do_build_gscam_foxy.sh ./scripts/do_build_gscam_foxy.sh
+RUN ./scripts/do_build_gscam_foxy.sh
+EOF

--- a/scripts/do_build_gscam_dashing.sh
+++ b/scripts/do_build_gscam_dashing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # 
 # Configure environment, run rosdep, and build
+# TODO I think we can use $ROS_DISTRO instead of dashing, thereby avoiding creating multiple do_build_foo.sh files
 cd ./gscam_ws/ \
     && source /opt/ros/dashing/setup.bash \
     && rosdep init \

--- a/scripts/do_build_gscam_dashing.sh
+++ b/scripts/do_build_gscam_dashing.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# 
+# Configure environment, run rosdep, and build
+cd ./gscam_ws/ \
+    && source /opt/ros/dashing/setup.bash \
+    && rosdep init \
+    && rosdep update \
+    && rosdep install -y --from-paths . --ignore-src \
+    && colcon build

--- a/scripts/do_build_gscam_eloquent.sh
+++ b/scripts/do_build_gscam_eloquent.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# 
+# Configure environment, run rosdep, and build
+cd ./gscam_ws/ \
+    && source /opt/ros/eloquent/setup.bash \
+    && rosdep init \
+    && rosdep update \
+    && rosdep install -y --from-paths . --ignore-src \
+    && colcon build

--- a/scripts/do_build_gscam_eloquent.sh
+++ b/scripts/do_build_gscam_eloquent.sh
@@ -3,7 +3,6 @@
 # Configure environment, run rosdep, and build
 cd ./gscam_ws/ \
     && source /opt/ros/eloquent/setup.bash \
-    && rosdep init \
     && rosdep update \
     && rosdep install -y --from-paths . --ignore-src \
     && colcon build

--- a/scripts/do_build_gscam_foxy.sh
+++ b/scripts/do_build_gscam_foxy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# 
+# Configure environment, run rosdep, and build
+cd ./gscam_ws/ \
+    && source /opt/ros/foxy/setup.bash \
+    && rosdep init \
+    && rosdep update \
+    && rosdep install -y --from-paths . --ignore-src \
+    && colcon build

--- a/scripts/do_clone_gscam.sh
+++ b/scripts/do_clone_gscam.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+# 
+# Get gscam source
+mkdir -p ./gscam_ws/src \
+  && cd ./gscam_ws/src \
+  && git clone https://github.com/clydemcqueen/gscam.git \
+  && cd gscam \
+  && git checkout ros2

--- a/scripts/do_clone_gscam.sh
+++ b/scripts/do_clone_gscam.sh
@@ -3,6 +3,4 @@
 # Get gscam source
 mkdir -p ./gscam_ws/src \
   && cd ./gscam_ws/src \
-  && git clone https://github.com/clydemcqueen/gscam.git \
-  && cd gscam \
-  && git checkout ros2
+  && git clone https://github.com/clydemcqueen/gscam.git -b ros2 \

--- a/scripts/do_get_dashing.sh
+++ b/scripts/do_get_dashing.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+# 
+# Get Dashing binaries
+apt update \
+    && apt install -y ros-dashing-ros-base

--- a/scripts/do_get_eloquent.sh
+++ b/scripts/do_get_eloquent.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+#
+# Get Eloquent binaries
+apt update \
+    && apt install -y ros-eloquent-ros-base

--- a/scripts/do_get_foxy.sh
+++ b/scripts/do_get_foxy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+#
+# Get Foxy binaries
+apt update \
+    && apt install -y ros-foxy-ros-base

--- a/scripts/do_get_gstreamer.sh
+++ b/scripts/do_get_gstreamer.sh
@@ -2,4 +2,7 @@
 # 
 # Get gstreamer
 apt update \
-    && apt install -y gstreamer1.0-tools libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev
+    && apt install -y libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+                      gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-doc gstreamer1.0-tools gstreamer1.0-x \
+                      gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio \
+                      libgstreamer-plugins-base1.0-dev

--- a/scripts/do_get_gstreamer.sh
+++ b/scripts/do_get_gstreamer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+# 
+# Get gstreamer
+apt update \
+    && apt install -y gstreamer1.0-tools libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev

--- a/scripts/do_prep_eloquent.sh
+++ b/scripts/do_prep_eloquent.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -x
+#
+# Set up the Locale
+apt install -y locales \
+    && locale-gen en_US en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+    && export LANG=en_US.UTF-8
+#
+# Add the ROS2 apt repository
+apt install -y curl gnupg2 lsb-release \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - \
+    && sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+#
+# Install dev tools and ROS tools
+apt update && apt install -y \
+    build-essential \
+    cmake \
+    git \
+    python3-colcon-common-extensions \
+    python3-pip \
+    python-rosdep \
+    python3-vcstool \
+    wget \
+  && python3 -m pip install -U \
+    argcomplete \
+    flake8 \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-docstrings \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures \
+    pytest \
+    pytest-cov \
+    pytest-runner \
+    setuptools \
+  && apt install --no-install-recommends -y \
+    libasio-dev \
+    libtinyxml2-dev \
+  && apt install --no-install-recommends -y \
+    libcunit1-dev

--- a/scripts/do_prep_foxy.sh
+++ b/scripts/do_prep_foxy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -x
+#
+# Set up the Locale
+apt install -y locales \
+    && locale-gen en_US en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+    && export LANG=en_US.UTF-8
+#
+# Add the ROS2 apt repository
+apt install -y curl gnupg2 lsb-release \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - \
+    && sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+#
+# Install dev tools and ROS tools
+# Changes from Eloquent!
+apt update && apt install -y \
+    build-essential \
+    cmake \
+    git \
+    libbullet-dev \
+    python3-colcon-common-extensions \
+    python3-flake8 \
+    python3-pip \
+    python3-pytest-cov \
+    python3-rosdep \
+    python3-setuptools \
+    python3-vcstool \
+    wget \
+  && python3 -m pip install -U \
+    argcomplete \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-docstrings \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures \
+    pytest \
+  && apt install --no-install-recommends -y \
+    libasio-dev \
+    libtinyxml2-dev \
+  && apt install --no-install-recommends -y \
+    libcunit1-dev

--- a/scripts/gscam_entrypoint.sh
+++ b/scripts/gscam_entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+
+. /workspace/gscam/install/setup.sh
+export GSCAM_CONFIG="videotestsrc pattern=snow ! video/x-raw,width=1280,height=720 ! videoconvert"
+exec "$@"


### PR DESCRIPTION
* added amd64 eloquent base and amd64 foxy base, should be generally useful
* add do_get_* to get ros2 binaries, should work on amd64 and arm64
* add builders for gscam

I was able to use this to compile the ros2 gscam port for Dashing, Eloquent and Foxy. The compile fails for Dashing -- but it's a problem with the gscam port, not the Docker scripts. The compile gives deprecation warnings for Foxy. Very cool!

Since I'm using the standard location for setup.bash (`/opt/ros/VERSION/setup.bash`), and `setup.bash` must be called before `rosdep` and before `colcon build`, I need 3 slightly different `build_VERSION_gscam.sh` scripts. This is a bit annoying.